### PR TITLE
Projeto Starwars Planets Search [ContextAPI e Hooks]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.1"

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,14 @@
 import React from 'react';
 import './App.css';
+import Table from './components/Table';
+import Provider from './context/Provider';
 
 function App() {
   return (
-    <span>Hello, App!</span>
+    <Provider>
+      <span>Hello, App!</span>
+      <Table />
+    </Provider>
   );
 }
 

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -1,0 +1,49 @@
+import React, { useContext } from 'react';
+import AppContext from '../context/Context';
+
+function Table() {
+  const data = useContext(AppContext);
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Rotation Period</th>
+          <th>Orbital Period</th>
+          <th>Diameter</th>
+          <th>Climate</th>
+          <th>Gravity</th>
+          <th>Terrain</th>
+          <th>Surface Water</th>
+          <th>Population</th>
+          <th>Created</th>
+          <th>Edited</th>
+          <th>URL</th>
+          <th>Buttons</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((planet) => (
+          <tr key={ `planet${planet.name}` }>
+            <td>{planet.name}</td>
+            <td>{planet.rotation_period}</td>
+            <td>{planet.orbital_period}</td>
+            <td>{planet.diameter}</td>
+            <td>{planet.climate}</td>
+            <td>{planet.gravity}</td>
+            <td>{planet.terrain}</td>
+            <td>{planet.surface_water}</td>
+            <td>{planet.population}</td>
+            <td>{planet.created}</td>
+            <td>{planet.edited}</td>
+            <td>{planet.url}</td>
+            <td>buttons</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default Table;

--- a/src/context/Context.js
+++ b/src/context/Context.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const AppContext = createContext();
+
+export default AppContext;

--- a/src/context/Provider.js
+++ b/src/context/Provider.js
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import AppContext from './Context';
+import planetsData from '../services';
+
+function Provider({ children }) {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const fetchPlanets = async () => {
+      const { results } = await planetsData();
+      setData(results);
+    };
+    fetchPlanets();
+  }, []);
+
+  return (
+    <AppContext.Provider value={ data }>
+      {children}
+    </AppContext.Provider>
+  );
+}
+
+Provider.propTypes = {
+  children: PropTypes.any,
+}.isRequired;
+
+export default Provider;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,0 +1,9 @@
+const fetchPlanets = async () => {
+  const endpoint = 'https://swapi-trybe.herokuapp.com/api/planets/';
+  const response = await fetch(endpoint);
+  const planets = await response.json();
+
+  return planets;
+};
+
+export default fetchPlanets;


### PR DESCRIPTION
Requisitos obrigatórios:

- [x] 1 - Faça uma requisição para o endpoint /planets da API de Star Wars e preencha uma tabela com os dados retornados, com exceção dos da coluna residents
- [ ] 2 - Filtre a tabela através de um texto, inserido num campo de texto, exibindo somente os planetas cujos nomes incluam o texto digitado
- [ ] 3 - Crie um filtro para valores numéricos
- [ ] 4 - Não utilize filtros repetidos
- [ ] 5 - Apague o filtro de valores numéricos e desfaça as filtragens dos dados da tabela ao clicar no ícone de X de um dos filtros

Requisitos bônus:

- [ ] 6 - Ordene as colunas de forma ascendente ou descendente